### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/Handler/Utils.hs
+++ b/Handler/Utils.hs
@@ -62,7 +62,7 @@ decodeToc :: Paper -> [Text]
 decodeToc = const [] -- maybe [] (T.splitOn "\t") . paperToc
 
 doi2url :: Text -> String
-doi2url doi = "http://dx.doi.org/" ++ T.unpack doi
+doi2url doi = "https://doi.org/" ++ T.unpack doi
 
 
 -- assumes cr is not used for id.

--- a/Model/PaperReaderTypes.hs
+++ b/Model/PaperReaderTypes.hs
@@ -21,7 +21,7 @@ absolutePath url path
 
 
 doi2url :: String -> String
-doi2url doi = "http://dx.doi.org/" ++ doi
+doi2url doi = "https://doi.org/" ++ doi
 
 -- emptyMisc = B.concat $ LB.toChunks $ MP.pack (M.fromList [] :: M.Map Int Int)
 

--- a/Parser/PaperReaderTypes.hs
+++ b/Parser/PaperReaderTypes.hs
@@ -126,7 +126,7 @@ absolutePath url path
 
 
 doi2url :: String -> String
-doi2url doi = "http://dx.doi.org/" ++ doi
+doi2url doi = "https://doi.org/" ++ doi
 
 
 emptyMisc :: B.ByteString

--- a/Parser/Publisher/ACS.hs
+++ b/Parser/Publisher/ACS.hs
@@ -241,7 +241,7 @@ _refs _ c = map mkRef $ Data.List.concat li
                     Just u -> Just $ predoi `T.append` u
                     Nothing -> Just $ (pre `T.append`) $ fromJust $ cit c
       pre = "http://alocator.web.fc2.com/?redirect=yes&q="
-      predoi = "http://dx.doi.org/"
+      predoi = "https://doi.org/"
       a :: Cursor -> Maybe Cursor
       a = headm . queryT [jq| div.citationLinks a |]
       getDoi :: Cursor -> Maybe T.Text

--- a/Parser/Publisher/Elsevier.hs
+++ b/Parser/Publisher/Elsevier.hs
@@ -18,8 +18,8 @@ module Parser.Publisher.Elsevier (
     elsevier1Reader,elsevier2Reader
 ) where
 
--- elsevier1Reader : Immunity: http://dx.doi.org/10.1016/j.immuni.2006.04.010
---                   Archives of Biochemistry and Biophysics:  http://dx.doi.org/10.1016/j.abb.2011.05.014
+-- elsevier1Reader : Immunity: https://doi.org/10.1016/j.immuni.2006.04.010
+--                   Archives of Biochemistry and Biophysics:  https://doi.org/10.1016/j.abb.2011.05.014
 -- elsevier2Reader : Not supported yet.
 --
 

--- a/templates/activity.mastache.html
+++ b/templates/activity.mastache.html
@@ -87,7 +87,7 @@
     <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" role="menu">
-    <li><a href='http://dx.doi.org/<%= doi %>'>Original</a></li>
+    <li><a href='https://doi.org/<%= doi %>'>Original</a></li>
     <li><a href="/paper/raw/<%= id %>">Raw</a></li>
     <li><a href="/paper/a/<%= id %>">Format A</a></li>
     <li><a href="/paper/b/<%= id %>">Format B</a></li>

--- a/templates/paperinfo_modal_withdata.hamlet
+++ b/templates/paperinfo_modal_withdata.hamlet
@@ -67,7 +67,7 @@
         $forall ref <- refs
           <li>
             $maybe doi <- (referenceCit ref >>= citationDoi)
-              <a href=#{T.append "http://dx.doi.org/" doi}>
+              <a href=#{T.append "https://doi.org/" doi}>
                 #{referenceRefName ref} : #{fromMaybe "" $ referenceCitText ref}
             $nothing
               #{referenceRefName ref} : #{fromMaybe "" $ referenceCitText ref}


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). It may be a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old `dx` subdomain is being redirected, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to all static DOI links and the code that generates new DOI links.

Cheers!